### PR TITLE
Refactoring the feature pack to create the ChatModel beans lazily.

### DIFF
--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/ai/injection/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/ai/injection/main/module.xml
@@ -22,6 +22,9 @@
 
     <dependencies>
         <module name="dev.langchain4j"/>
+        <module name="dev.langchain4j.mistral-ai" optional="true"/>
+        <module name="dev.langchain4j.ollama" optional="true"/>
+        <module name="dev.langchain4j.openai" optional="true"/>
         <module name="io.smallrye.llm"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.servlet.api"/>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/ai/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/ai/main/module.xml
@@ -17,10 +17,8 @@
 
     <dependencies>
         <module name="dev.langchain4j"/>
-        <module name="dev.langchain4j.mistral-ai" optional="true"/>
         <module name="dev.langchain4j.neo4j" optional="true"/>
         <module name="dev.langchain4j.ollama" optional="true"/>
-        <module name="dev.langchain4j.openai" optional="true"/>
         <module name="dev.langchain4j.weaviate" optional="true"/>
         <module name="dev.langchain4j.web-search-engines" optional="true"/>
         <module name="io.smallrye.jandex"/>

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/AILogger.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/AILogger.java
@@ -7,19 +7,17 @@ package org.wildfly.extension.ai.injection;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
-/**
- * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
- */
 @MessageLogger(projectCode = "WFAIINJC", length = 5)
 public interface AILogger extends BasicLogger {
 
-    AILogger ROOT_LOGGER = Logger.getMessageLogger(AILogger.class, "org.wildfly.extension.ai.injection");
+    AILogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), AILogger.class, "org.wildfly.extension.ai.injection");
  /**
      * Logs a warning message indicating the address, represented by the {@code address} parameter, could not be
      * resolved, so cannot match it to any InetAddress.
@@ -28,4 +26,7 @@ public interface AILogger extends BasicLogger {
     @Message(id = 1, value = "The deployment does not have Jakarta Dependency Injection enabled.")
     void cdiRequired();
 
+
+    @Message(id = 2, value = "The bean name %s is expecting a %s while the llm is configured as streaming %s")
+    IllegalStateException incorrectLLMConfiguration(String name, String typeClass, boolean streaming);
 }

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/WildFlyBeanRegistry.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/WildFlyBeanRegistry.java
@@ -7,6 +7,7 @@ package org.wildfly.extension.ai.injection;
 import static org.wildfly.extension.ai.injection.WildFlyLLMConfig.registerBean;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
@@ -16,16 +17,22 @@ import jakarta.enterprise.inject.spi.Extension;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 
 public class WildFlyBeanRegistry {
-    private static final Map<String, ChatLanguageModel> chatModels = new HashMap<>();
+
+    private static final Map<String, WildFlyChatModelConfig> chatModels = new HashMap<>();
     private static final Map<String, EmbeddingModel> embeddingModels = new HashMap<>();
     private static final Map<String, EmbeddingStore> embeddingStores = new HashMap<>();
     private static final Map<String, ContentRetriever> contentRetrievers = new HashMap<>();
 
-    public static final void registerChatLanguageModel(String id, ChatLanguageModel chatModel) {
+    public static final void registerChatLanguageModel(String id, WildFlyChatModelConfig chatModel) {
         chatModels.put(id, chatModel);
-        registerBean(id, chatModel, ChatLanguageModel.class);
+        if (chatModel.isStreaming()) {
+            registerBean(id, chatModel, StreamingChatLanguageModel.class);
+        } else {
+            registerBean(id, chatModel, ChatLanguageModel.class);
+        }
     }
 
     public static void registerEmbeddingModel(String id, EmbeddingModel embeddingModel) {
@@ -42,6 +49,7 @@ public class WildFlyBeanRegistry {
         contentRetrievers.put(id, contentRetriever);
         registerBean(id, contentRetriever, ContentRetriever.class);
     }
+
     public static final List<Extension> getCDIExtensions() {
         return List.of(new LangChain4JPluginsPortableExtension(), new LangChain4JAIServicePortableExtension());
     }

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyChatModelConfig.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyChatModelConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.ai.injection.chat;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import java.util.List;
+
+public interface WildFlyChatModelConfig {
+
+    ChatLanguageModel createLanguageModel(List<ChatModelListener> listeners);
+
+    StreamingChatLanguageModel createStreamingLanguageModel(List<ChatModelListener> listeners);
+
+    boolean isStreaming();
+}

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyMistralAiChatModelLanguage.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyMistralAiChatModelLanguage.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.ai.injection.chat;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.mistralai.MistralAiChatModel;
+import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+
+public class WildFlyMistralAiChatModelLanguage implements WildFlyChatModelConfig {
+
+    private String key;
+    private String baseUrl;
+    private Boolean logRequests;
+    private Boolean logResponses;
+    private Integer maxTokens;
+    private String modelName;
+    private Integer randomSeed;
+    private Boolean safePrompt;
+    private Double temperature;
+    private long connectTimeOut;
+    private Double topP;
+    private boolean isJson;
+    private boolean streaming;
+
+    @Override
+    public ChatLanguageModel createLanguageModel(List<ChatModelListener> listeners) {
+        MistralAiChatModel.MistralAiChatModelBuilder builder = MistralAiChatModel.builder()
+                .apiKey(key)
+                .baseUrl(baseUrl)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .maxRetries(5)
+                .maxTokens(maxTokens)
+                .modelName(modelName)
+                .randomSeed(randomSeed)
+                .safePrompt(safePrompt)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .topP(topP);
+        if (isJson) {
+            builder.responseFormat("json_object");
+        }
+        return builder.build();
+    }
+
+    @Override
+    public StreamingChatLanguageModel createStreamingLanguageModel(List<ChatModelListener> listeners) {
+        MistralAiStreamingChatModel.MistralAiStreamingChatModelBuilder builder = MistralAiStreamingChatModel.builder()
+                .apiKey(key)
+                .baseUrl(baseUrl)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .maxTokens(maxTokens)
+                .modelName(modelName)
+                .randomSeed(randomSeed)
+                .safePrompt(safePrompt)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .topP(topP);
+        if (isJson) {
+            builder.responseFormat("json_object");
+        }
+        return builder.build();
+    }
+
+    public WildFlyMistralAiChatModelLanguage apiKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage baseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage logRequests(Boolean logRequests) {
+        this.logRequests = logRequests;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage logResponses(Boolean logResponses) {
+        this.logResponses = logResponses;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage maxTokens(Integer maxTokens) {
+        this.maxTokens = maxTokens;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage modelName(String modelName) {
+        this.modelName = modelName;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage randomSeed(Integer randomSeed) {
+        this.randomSeed = randomSeed;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage safePrompt(Boolean safePrompt) {
+        this.safePrompt = safePrompt;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage setJson(boolean isJson) {
+        this.isJson = isJson;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage temperature(Double temperature) {
+        this.temperature = temperature;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage timeout(long timeOut) {
+        this.connectTimeOut = timeOut;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage topP(Double topP) {
+        this.topP = topP;
+        return this;
+    }
+
+    public WildFlyMistralAiChatModelLanguage streaming(boolean streaming) {
+        this.streaming = streaming;
+        return this;
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return streaming;
+    }
+}

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyOllamaChatModelConfig.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyOllamaChatModelConfig.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.ai.injection.chat;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+
+public class WildFlyOllamaChatModelConfig implements WildFlyChatModelConfig {
+
+    private String baseUrl;
+    private Boolean logRequests;
+    private Boolean logResponses;
+    private boolean isJson;
+    private Integer maxRetries;
+    private Double temperature;
+    private long connectTimeOut;
+    private String modelName;
+    private boolean streaming;
+
+    @Override
+    public ChatLanguageModel createLanguageModel(List<ChatModelListener> listeners) {
+        OllamaChatModel.OllamaChatModelBuilder builder = OllamaChatModel.builder()
+                .baseUrl(baseUrl)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .maxRetries(maxRetries)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .modelName(modelName);
+        if (isJson) {
+            builder.format("json");
+        }
+        return builder.build();
+    }
+
+    @Override
+    public StreamingChatLanguageModel createStreamingLanguageModel(List<ChatModelListener> listeners) {
+        OllamaStreamingChatModel.OllamaStreamingChatModelBuilder builder = OllamaStreamingChatModel.builder()
+                .baseUrl(baseUrl)
+                .listeners(listeners)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .modelName(modelName);
+        if (isJson) {
+            builder.format("json");
+        }
+        return builder.build();
+    }
+
+    public WildFlyOllamaChatModelConfig baseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig logRequests(Boolean logRequests) {
+        this.logRequests = logRequests;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig logResponses(Boolean logResponses) {
+        this.logResponses = logResponses;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig setJson(boolean isJson) {
+        this.isJson = isJson;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig maxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig temperature(Double temperature) {
+        this.temperature = temperature;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig timeout(long connectTimeOut) {
+        this.connectTimeOut = connectTimeOut;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig modelName(String modelName) {
+        this.modelName = modelName;
+        return this;
+    }
+
+    public WildFlyOllamaChatModelConfig streaming(boolean streaming) {
+        this.streaming = streaming;
+        return this;
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+}

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyOpenAiChatModelConfig.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/chat/WildFlyOpenAiChatModelConfig.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.ai.injection.chat;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+
+public class WildFlyOpenAiChatModelConfig implements WildFlyChatModelConfig {
+
+    private String key;
+    private String baseUrl;
+    private Double frequencyPenalty;
+    private Boolean logRequests;
+    private Boolean logResponses;
+    private Integer maxToken;
+    private String modelName;
+    private String organizationId;
+    private Double presencePenalty;
+    private Integer seed;
+    private Double temperature;
+    private long connectTimeOut;
+    private Double topP;
+    private boolean isJson;
+    private boolean streaming;
+
+    @Override
+    public ChatLanguageModel createLanguageModel(List<ChatModelListener> listeners) {
+        OpenAiChatModel.OpenAiChatModelBuilder builder = OpenAiChatModel.builder()
+                .apiKey(key)
+                .baseUrl(baseUrl)
+                .frequencyPenalty(frequencyPenalty)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .maxRetries(5)
+                .maxTokens(maxToken)
+                .modelName(modelName)
+                .organizationId(organizationId)
+                .presencePenalty(presencePenalty)
+                .seed(seed)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .topP(topP);
+        if (isJson) {
+            builder.responseFormat("json_object");
+        }
+        return builder.build();
+    }
+
+    @Override
+    public StreamingChatLanguageModel createStreamingLanguageModel(List<ChatModelListener> listeners) {
+        OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder = OpenAiStreamingChatModel.builder()
+                .apiKey(key)
+                .baseUrl(baseUrl)
+                .frequencyPenalty(frequencyPenalty)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .listeners(listeners)
+                .maxTokens(maxToken)
+                .modelName(modelName)
+                .organizationId(organizationId)
+                .presencePenalty(presencePenalty)
+                .seed(seed)
+                .temperature(temperature)
+                .timeout(Duration.ofMillis(connectTimeOut))
+                .topP(topP);
+        if (isJson) {
+            builder.responseFormat("json_object");
+        }
+        return builder.build();
+    }
+
+    public WildFlyOpenAiChatModelConfig apiKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig baseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig frequencyPenalty(Double frequencyPenalty) {
+        this.frequencyPenalty = frequencyPenalty;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig logRequests(Boolean logRequests) {
+        this.logRequests = logRequests;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig logResponses(Boolean logResponses) {
+        this.logResponses = logResponses;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig maxTokens(Integer maxToken) {
+        this.maxToken = maxToken;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig modelName(String modelName) {
+        this.modelName = modelName;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig organizationId(String organizationId) {
+        this.organizationId = organizationId;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig presencePenalty(Double presencePenalty) {
+        this.presencePenalty = presencePenalty;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig seed(Integer seed) {
+        this.seed = seed;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig temperature(Double temperature) {
+        this.temperature = temperature;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig timeout(long connectTimeOut) {
+        this.connectTimeOut = connectTimeOut;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig topP(Double topP) {
+        this.topP = topP;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig setJson(boolean isJson) {
+        this.isJson = isJson;
+        return this;
+    }
+
+    public WildFlyOpenAiChatModelConfig streaming(boolean streaming) {
+        this.streaming = streaming;
+        return this;
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return streaming;
+    }
+}

--- a/wildfly-ai/pom.xml
+++ b/wildfly-ai/pom.xml
@@ -22,5 +22,23 @@
         <module>subsystem</module>
         <module>injection</module>
     </modules>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mistral-ai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-weaviate</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/wildfly-ai/subsystem/pom.xml
+++ b/wildfly-ai/subsystem/pom.xml
@@ -121,15 +121,6 @@
             <artifactId>onnxruntime</artifactId>
         </dependency>
         <!-- required for embeddings -->
-
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-mistral-ai</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-open-ai</artifactId>
-        </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-ollama</artifactId>

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/Capabilities.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/Capabilities.java
@@ -4,19 +4,15 @@
  */
 package org.wildfly.extension.ai;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
 
-/**
- *
- * @author Emmanuel Hugonnet (c) 2024 Red Hat, Inc.
- */
 public interface Capabilities {
-    UnaryServiceDescriptor<ChatLanguageModel> CHAT_MODEL_PROVIDER_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ai.chatmodel", ChatLanguageModel.class);
+    UnaryServiceDescriptor<WildFlyChatModelConfig> CHAT_MODEL_PROVIDER_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ai.chatmodel", WildFlyChatModelConfig.class);
     RuntimeCapability<Void> CHAT_MODEL_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of(CHAT_MODEL_PROVIDER_DESCRIPTOR).setAllowMultipleRegistrations(true).build();
 
     UnaryServiceDescriptor<EmbeddingModel> EMBEDDING_MODEL_PROVIDER_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ai.embedding.model", EmbeddingModel.class);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/AbstractChatModelProviderServiceConfigurator.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/AbstractChatModelProviderServiceConfigurator.java
@@ -6,29 +6,25 @@ package org.wildfly.extension.ai.chat;
 
 import static org.wildfly.extension.ai.Capabilities.CHAT_MODEL_PROVIDER_CAPABILITY;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.jboss.as.controller.OperationContext;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueRegistry;
 import org.wildfly.subsystem.service.ResourceServiceConfigurator;
 import org.wildfly.subsystem.service.ResourceServiceInstaller;
 import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
 
-/**
- *
- * @author Emmanuel Hugonnet (c) 2024 Red Hat, Inc.
- */
 public abstract class AbstractChatModelProviderServiceConfigurator implements ResourceServiceConfigurator {
 
-    private final ValueRegistry<String, ChatLanguageModel> registry;
+    private final ValueRegistry<String, WildFlyChatModelConfig> registry;
 
-    AbstractChatModelProviderServiceConfigurator(ValueRegistry<String, ChatLanguageModel> registry) {
+    AbstractChatModelProviderServiceConfigurator(ValueRegistry<String, WildFlyChatModelConfig> registry) {
         this.registry = registry;
     }
 
-    ResourceServiceInstaller installService(final String name, Supplier<ChatLanguageModel> factory) {
-        Consumer<ChatLanguageModel> captor = registry.add(name);
+    ResourceServiceInstaller installService(final String name, Supplier<WildFlyChatModelConfig> factory) {
+        Consumer<WildFlyChatModelConfig> captor = registry.add(name);
         ResourceServiceInstaller installer = CapabilityServiceInstaller.builder(CHAT_MODEL_PROVIDER_CAPABILITY, factory)
                 .withCaptor(captor)
                 .asActive()

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/ChatModelConnectionCheckerOperationHandler.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/ChatModelConnectionCheckerOperationHandler.java
@@ -7,7 +7,7 @@ package org.wildfly.extension.ai.chat;
 import static org.jboss.dmr.ModelType.STRING;
 import static org.wildfly.extension.ai.AIAttributeDefinitions.USER_MESSAGE;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import java.util.Collections;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -16,6 +16,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.ai.AILogger;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.FunctionExecutor;
 import org.wildfly.service.capture.ValueExecutorRegistry;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
@@ -27,7 +28,7 @@ import org.wildfly.subsystem.resource.ResourceDescriptor;
 public class ChatModelConnectionCheckerOperationHandler implements OperationStepHandler {
     private static final String OPERATION_NAME = "chat";
 
-    public static void register(final ManagementResourceRegistration registration, final ResourceDescriptor descriptor, ValueExecutorRegistry<String, ChatLanguageModel> registry) {
+    public static void register(final ManagementResourceRegistration registration, final ResourceDescriptor descriptor, ValueExecutorRegistry<String, WildFlyChatModelConfig> registry) {
         registration.registerOperationHandler(SimpleOperationDefinitionBuilder.of(OPERATION_NAME, descriptor.getResourceDescriptionResolver())
                 .setParameters(USER_MESSAGE)
                 .setReplyType(STRING)
@@ -37,22 +38,22 @@ public class ChatModelConnectionCheckerOperationHandler implements OperationStep
                 .build(), new ChatModelConnectionCheckerOperationHandler(registry));
     }
 
-    private final ValueExecutorRegistry<String, ChatLanguageModel> registry;
+    private final ValueExecutorRegistry<String, WildFlyChatModelConfig> registry;
 
-    ChatModelConnectionCheckerOperationHandler(ValueExecutorRegistry<String, ChatLanguageModel> registry) {
+    ChatModelConnectionCheckerOperationHandler(ValueExecutorRegistry<String, WildFlyChatModelConfig> registry) {
         this.registry = registry;
     }
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         String userMessage = USER_MESSAGE.resolveModelAttribute(context, operation).asString();
-        FunctionExecutor<ChatLanguageModel> executor = registry.getExecutor(context.getCurrentAddressValue());
+        FunctionExecutor<WildFlyChatModelConfig> executor = registry.getExecutor(context.getCurrentAddressValue());
         if(executor == null) {
             throw AILogger.ROOT_LOGGER.chatLanguageModelServiceUnavailable(context.getCurrentAddressValue());
         }
-        ModelNode answer = executor.execute((ChatLanguageModel chatLanguageModel) -> {
+        ModelNode answer = executor.execute((WildFlyChatModelConfig chatLanguageModelConfig) -> {
             AILogger.ROOT_LOGGER.debug("About to execute a chat call to the LLM with the following user message: " + userMessage);
-            String response = chatLanguageModel.generate(userMessage);
+            String response = (chatLanguageModelConfig.createLanguageModel(Collections.emptyList())).generate(userMessage);
             AILogger.ROOT_LOGGER.debug("This is the answer I got: " + response);
             return new ModelNode(response);
         });

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/MistralAIChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/MistralAIChatLanguageModelProviderRegistrar.java
@@ -16,7 +16,6 @@ import static org.wildfly.extension.ai.AIAttributeDefinitions.TEMPERATURE;
 import static org.wildfly.extension.ai.AIAttributeDefinitions.TOP_P;
 import static org.wildfly.extension.ai.Capabilities.CHAT_MODEL_PROVIDER_CAPABILITY;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import java.util.Collection;
 import java.util.List;
 import org.jboss.as.controller.AttributeDefinition;
@@ -29,6 +28,7 @@ import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
 import org.jboss.dmr.ModelType;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueExecutorRegistry;
 
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -53,7 +53,7 @@ public class MistralAIChatLanguageModelProviderRegistrar implements ChildResourc
     private final ResourceDescriptor descriptor;
     static final String NAME = "mistral-ai-chat-model";
     public static final PathElement PATH = PathElement.pathElement(NAME);
-    private final ValueExecutorRegistry<String, ChatLanguageModel> registry = ValueExecutorRegistry.newInstance();
+    private final ValueExecutorRegistry<String, WildFlyChatModelConfig> registry = ValueExecutorRegistry.newInstance();
 
     public MistralAIChatLanguageModelProviderRegistrar(ParentResourceDescriptionResolver parentResolver) {
         this.registration = ResourceRegistration.of(PATH);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OllamaChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OllamaChatLanguageModelProviderRegistrar.java
@@ -25,7 +25,7 @@ import org.jboss.as.controller.registry.RuntimePackageDependency;
 
 import static org.wildfly.extension.ai.AIAttributeDefinitions.RESPONSE_FORMAT;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueExecutorRegistry;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -42,7 +42,7 @@ public class OllamaChatLanguageModelProviderRegistrar implements ChildResourceDe
     private final ResourceDescriptor descriptor;
     static final String NAME = "ollama-chat-model";
     public static final PathElement PATH = PathElement.pathElement(NAME);
-    private final ValueExecutorRegistry<String, ChatLanguageModel> registry = ValueExecutorRegistry.newInstance();
+    private final ValueExecutorRegistry<String, WildFlyChatModelConfig> registry = ValueExecutorRegistry.newInstance();
 
     public OllamaChatLanguageModelProviderRegistrar(ParentResourceDescriptionResolver parentResolver) {
         this.registration = ResourceRegistration.of(PATH);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OpenAIChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OpenAIChatLanguageModelProviderRegistrar.java
@@ -30,7 +30,7 @@ import org.jboss.dmr.ModelType;
 import static org.wildfly.extension.ai.AIAttributeDefinitions.RESPONSE_FORMAT;
 import static org.wildfly.extension.ai.AIAttributeDefinitions.TOP_P;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueExecutorRegistry;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -61,7 +61,7 @@ public class OpenAIChatLanguageModelProviderRegistrar implements ChildResourceDe
     private final ResourceDescriptor descriptor;
     static final String NAME = "openai-chat-model";
     public static final PathElement PATH = PathElement.pathElement(NAME);
-    private final ValueExecutorRegistry<String, ChatLanguageModel> registry = ValueExecutorRegistry.newInstance();
+    private final ValueExecutorRegistry<String, WildFlyChatModelConfig> registry = ValueExecutorRegistry.newInstance();
 
     public OpenAIChatLanguageModelProviderRegistrar(ParentResourceDescriptionResolver parentResolver) {
         this.registration = ResourceRegistration.of(PATH);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIAttachements.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIAttachements.java
@@ -4,12 +4,12 @@
  */
 package org.wildfly.extension.ai.deployment;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.AttachmentList;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 
 /**
  *
@@ -17,7 +17,7 @@ import org.jboss.as.server.deployment.AttachmentList;
  */
 public class AIAttachements {
 
-    static final AttachmentKey<AttachmentList<ChatLanguageModel>> CHAT_MODELS = AttachmentKey.createList(ChatLanguageModel.class);
+    static final AttachmentKey<AttachmentList<WildFlyChatModelConfig>> CHAT_MODELS = AttachmentKey.createList(WildFlyChatModelConfig.class);
     static final AttachmentKey<AttachmentList<String>> CHAT_MODEL_KEYS = AttachmentKey.createList(String.class);
     static final AttachmentKey<AttachmentList<EmbeddingModel>> EMBEDDING_MODELS = AttachmentKey.createList(EmbeddingModel.class);
     static final AttachmentKey<AttachmentList<String>> EMBEDDING_MODEL_KEYS = AttachmentKey.createList(String.class);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIDeploymentProcessor.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIDeploymentProcessor.java
@@ -7,7 +7,6 @@ package org.wildfly.extension.ai.deployment;
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 import static org.wildfly.extension.ai.AILogger.ROOT_LOGGER;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
@@ -21,6 +20,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.weld.WeldCapability;
 import org.wildfly.extension.ai.injection.WildFlyBeanRegistry;
+import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 
 /**
  *
@@ -37,7 +37,7 @@ public class AIDeploymentProcessor implements DeploymentUnitProcessor {
             if (weldCapability != null && !weldCapability.isPartOfWeldDeployment(deploymentUnit)) {
                 ROOT_LOGGER.cdiRequired();
             }
-            List<ChatLanguageModel> requiredChatModels = deploymentUnit.getAttachmentList(AIAttachements.CHAT_MODELS);
+            List<WildFlyChatModelConfig> requiredChatModels = deploymentUnit.getAttachmentList(AIAttachements.CHAT_MODELS);
             List<String> chatLanguageModelNames = deploymentUnit.getAttachmentList(AIAttachements.CHAT_MODEL_KEYS);
             List<EmbeddingModel> requiredEmbeddingModels = deploymentUnit.getAttachmentList(AIAttachements.EMBEDDING_MODELS);
             List<String> requiredEmbeddingModelNames = deploymentUnit.getAttachmentList(AIAttachements.EMBEDDING_MODEL_KEYS);


### PR DESCRIPTION
Instead of creating the LangChain4J ChatLanguageModel beans directly we create a config object that will create them when thy are to be used.
This prepares also support for StreamingChatLanguageModel