### PR TITLE
Upgrade to LangChain4J 1.0.0-alpha1 and Smallrye LLM 0.0.2

### DIFF
--- a/ai-feature-pack/pom.xml
+++ b/ai-feature-pack/pom.xml
@@ -200,10 +200,6 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.neo4j.driver</groupId>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/com/squareup/retrofit2/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/com/squareup/retrofit2/main/module.xml
@@ -15,7 +15,6 @@
         <artifact name="${com.squareup.retrofit2:converter-jackson}"/>
         <artifact name="${com.squareup.retrofit2:retrofit}"/>
         <artifact name="${org.jetbrains.kotlin:kotlin-stdlib}"/>
-        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-common}"/>
         <artifact name="${com.squareup.okhttp3:okhttp}"/>
         <artifact name="${com.squareup.okhttp3:okhttp-sse}"/>
         <artifact name="${com.squareup.okio:okio}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -40,18 +40,18 @@
 
         <version.ai.djl>0.30.0</version.ai.djl>
         <version.com.google.apis>v1-rev20240417-2.0.0</version.com.google.apis>
-        <version.com.knuddels.jtokkit>1.0.0</version.com.knuddels.jtokkit>
+        <version.com.knuddels.jtokkit>1.1.0</version.com.knuddels.jtokkit>
         <version.com.microsoft.onnxruntime>1.20.0</version.com.microsoft.onnxruntime>
         <version.com.squareup.okhttp>4.12.0</version.com.squareup.okhttp>
         <version.com.squareup.okio-jvm>3.6.0</version.com.squareup.okio-jvm>
         <version.com.squareup.retrofit2>2.9.0</version.com.squareup.retrofit2>
         <version.commons-compress>1.26.1</version.commons-compress>
-        <version.dev.ai4j.openai4j>0.23.0</version.dev.ai4j.openai4j>
-        <version.dev.langchain4j>0.36.1</version.dev.langchain4j>
-        <version.io.smallrye.llm>0.0.1</version.io.smallrye.llm>
+        <version.dev.ai4j.openai4j>0.25.0</version.dev.ai4j.openai4j>
+        <version.dev.langchain4j>1.0.0-alpha1</version.dev.langchain4j>
+        <version.io.smallrye.llm>0.0.2</version.io.smallrye.llm>
         <version.io.weaviate.client>4.9.0</version.io.weaviate.client>
         <version.net.java.dev.jna>5.13.0</version.net.java.dev.jna>
-        <version.org.jetbrains.kotlin>1.9.25</version.org.jetbrains.kotlin>
+        <version.org.jetbrains.kotlin>2.1.0</version.org.jetbrains.kotlin>
         <version.org.neo4j.cypher>2024.2.0</version.org.neo4j.cypher>
         <version.org.neo4j.driver>5.26.3</version.org.neo4j.driver>
         <version.org.reactivestreams.reactive-streams>1.0.4</version.org.reactivestreams.reactive-streams>
@@ -468,18 +468,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${version.org.jetbrains.kotlin}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            
+
             <dependency>
                 <groupId>org.neo4j.driver</groupId>
                 <artifactId>neo4j-java-driver</artifactId>

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/WildFlyLLMConfig.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/WildFlyLLMConfig.java
@@ -4,7 +4,6 @@
  */
 package org.wildfly.extension.ai.injection;
 
-import static io.smallrye.llm.core.langchain4j.core.config.spi.LLMConfig.VALUE;
 import static io.smallrye.llm.core.langchain4j.core.config.spi.LLMConfig.getBeanPropertyName;
 import static org.wildfly.extension.ai.injection.AILogger.ROOT_LOGGER;
 
@@ -12,30 +11,37 @@ import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import io.smallrye.llm.core.langchain4j.core.config.spi.LLMConfig;
+import io.smallrye.llm.core.langchain4j.core.config.spi.ProducerFunction;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
-import java.util.ArrayList;
+import jakarta.enterprise.inject.Instance.Handle;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 
 public class WildFlyLLMConfig implements LLMConfig {
 
     private static final Set<String> beanNames = new HashSet<>();
     private static final Map<String, Object> beanData = new HashMap<>();
+    private static final String BEAN_VALUE = "defined_bean_value";
+    private static final String BEAN_CLASS = "defined_bean_class";
+    private static final String CLASS = "class";
+    private static final String SCOPE = "scope";
 
     public static void registerBean(String name, Object value, Class<?> type) {
         beanNames.add(name);
-        beanData.put(getBeanPropertyName(name, VALUE), value);
-        beanData.put(getBeanPropertyName(name, "class"), type.getName());
-        beanData.put(getBeanPropertyName(name, "scope"), ApplicationScoped.class.getName());
-    }
+        beanData.put(getBeanPropertyName(name, BEAN_VALUE), value);
+        beanData.put(getBeanPropertyName(name, BEAN_CLASS), type);
+        beanData.put(getBeanPropertyName(name, CLASS), type.getName());
+        beanData.put(getBeanPropertyName(name, SCOPE), ApplicationScoped.class.getName());
+        //provide callback
 
+    }
 
     @Override
     public void init() {
@@ -49,18 +55,31 @@ public class WildFlyLLMConfig implements LLMConfig {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getBeanPropertyValue(String beanName, String propertyName, Class<T> type) {
-        if(VALUE.equals(propertyName) && (ChatLanguageModel.class.isAssignableFrom(type) || StreamingChatLanguageModel.class.isAssignableFrom(type))) {
-            Instance<ChatModelListener> chatModelListenerInstance = CDI.current().select(ChatModelListener.class);
-            List<ChatModelListener> listeners = Collections.checkedList(new ArrayList<>(), ChatModelListener.class);
-            chatModelListenerInstance.forEach(listeners::add);
-            WildFlyChatModelConfig config = (WildFlyChatModelConfig) beanData.get(getBeanPropertyName(beanName, propertyName));
-            if(ChatLanguageModel.class.isAssignableFrom(type) && !config.isStreaming()) {
-                return (T) config.createLanguageModel(listeners);
+        if (PRODUCER.equals(propertyName)) {
+            Class<?> expectedType = (Class<?>) beanData.get(getBeanPropertyName(beanName, BEAN_CLASS));
+            if (ChatLanguageModel.class.isAssignableFrom(expectedType) || StreamingChatLanguageModel.class.isAssignableFrom(expectedType)) {
+                return (T) new ProducerFunction<Object>() {
+                    @Override
+                    public Object produce(Instance<Object> lookup, String beanName) {
+                        List<ChatModelListener> listeners = lookup.select(ChatModelListener.class).handlesStream().map(Handle<ChatModelListener>::get).collect(Collectors.toList() );
+                        WildFlyChatModelConfig config = (WildFlyChatModelConfig) beanData.get(getBeanPropertyName(beanName, BEAN_VALUE));
+                        if (ChatLanguageModel.class.isAssignableFrom(expectedType) && !config.isStreaming()) {
+                            return (T) config.createLanguageModel(listeners);
+                        }
+                        if (StreamingChatLanguageModel.class.isAssignableFrom(expectedType) && config.isStreaming()) {
+                            return (T) config.createStreamingLanguageModel(listeners);
+                        }
+                        throw ROOT_LOGGER.incorrectLLMConfiguration(beanName, expectedType.getName(), config.isStreaming());
+                    }
+                };
+            } else {
+                return (T) new ProducerFunction<Object>() {
+                    @Override
+                    public Object produce(Instance<Object> lookup, String beanName) {
+                        return beanData.get(getBeanPropertyName(beanName, BEAN_VALUE));
+                    }
+                };
             }
-            if(StreamingChatLanguageModel.class.isAssignableFrom(type) && config.isStreaming()) {
-                return (T) config.createStreamingLanguageModel(listeners);
-            }
-            throw ROOT_LOGGER.incorrectLLMConfiguration(beanName, type.getName(), config.isStreaming());
         }
         return (T) beanData.get(getBeanPropertyName(beanName, propertyName));
     }

--- a/wildfly-ai/subsystem/pom.xml
+++ b/wildfly-ai/subsystem/pom.xml
@@ -160,10 +160,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>


### PR DESCRIPTION
* Upgrading to LangChain4J 1.0.0-alpha1
* Upgrading kotlin to 2.1.0 and dropping kotlin-stdlib-common
* Upgrading to smallrye-llm 0.0.2

Issue #38