### PR TITLE
Fixing the layers for MCP server

### DIFF
--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
@@ -3,13 +3,13 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mcp">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mcp-server">
     <props>
         <prop name="org.wildfly.rule.class" value="org.wildfly.mcp.api.*"/>
         <prop name="org.wildfly.rule.annotations" value="org.wildfly.mcp.api.*"/>
     </props>
     <dependencies>
-        <layer name="ai"/>
+        <layer name="mcp"/>
     </dependencies>
     <feature spec="subsystem.mcp">
         <feature spec="subsystem.mcp.mcp-server">

--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp/layer-spec.xml
@@ -3,10 +3,13 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mcp-server">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mcp">
     <props>
         <prop name="org.wildfly.rule.class" value="org.wildfly.mcp.api.*"/>
         <prop name="org.wildfly.rule.annotations" value="org.wildfly.mcp.api.*"/>
     </props>
+    <dependencies>
+        <layer name="ee-concurrency"/>
+    </dependencies>
     <feature spec="subsystem.mcp" />
 </layer-spec>

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPAttachements.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPAttachements.java
@@ -6,11 +6,9 @@ package org.wildfly.extension.mcp.deployment;
 
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.wildfly.extension.mcp.McpEndpointConfiguration;
-import org.wildfly.extension.mcp.api.McpMetadata;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 
 public class MCPAttachements {
     static final AttachmentKey<McpEndpointConfiguration> MCP_ENDPOINT_CONFIGURATION = AttachmentKey.create(McpEndpointConfiguration.class);
-    static final AttachmentKey<McpMetadata> MCP_METADATA = AttachmentKey.create(McpMetadata.class);
     static final AttachmentKey<WildFlyMCPRegistry> MCP_REGISTRY_METADATA = AttachmentKey.create(WildFlyMCPRegistry.class);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerDependencyProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerDependencyProcessor.java
@@ -90,7 +90,7 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
                             null,
                             arguments, 
                             info.declaringClass().toString(),
-                            annotation.target().asMethod().returnType().asClassType().toString())
+                            annotation.target().asMethod().returnType().name().toString())
             );
             registry.addPrompt(name, metadata);
         }
@@ -125,7 +125,7 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
                             null,
                             arguments, 
                             info.declaringClass().toString(),
-                            annotation.target().asMethod().returnType().asClassType().toString())
+                            annotation.target().asMethod().returnType().name().toString())
             );
             registry.addTool(name, metadata);
         }
@@ -162,7 +162,7 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
                             mimeType,
                             arguments, 
                             info.declaringClass().toString(),
-                            annotation.target().asMethod().returnType().asClassType().toString())
+                            annotation.target().asMethod().returnType().name().toString())
             );
             registry.addResource(uri, metadata);
         }


### PR DESCRIPTION
Fixing the layers for MCP server
Adding missing dependency in layers.
Cleaning the code a bit
Avoiding issue if the return type is Parametrized

Fixing:
* https://github.com/wildfly-extras/wildfly-ai-feature-pack/issues/93
* https://github.com/wildfly-extras/wildfly-ai-feature-pack/issues/94