### PR TITLE
ci: JDK 24 is now GA, update reference link to adoptium, use itemizat…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).
-        # https://www.oracle.com/java/technologies/java-se-support-roadmap.html
-        java: [ 17, 21, 23 ]
+        # Reference: https://adoptium.net/support/
+        java:
+          - 17
+          - 21
+          - 24
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,4 +34,4 @@ jobs:
           cache: maven
       - name: Build with Maven
         # The module 'wildfly-ai-feature-pack' requires the 'install' goal
-        run: mvn --batch-mode --no-transfer-progress install
+        run: ./mvnw --batch-mode --no-transfer-progress clean install


### PR DESCRIPTION
…ion in workflow definitions, use maven-wrapper for reproducible builds, add clean maven target since the build employs it.