### PR TITLE
Integrating chicory-sdk to provide support for WASM WASI binaries in …

### DIFF
--- a/ai-feature-pack/pom.xml
+++ b/ai-feature-pack/pom.xml
@@ -46,6 +46,18 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-mcp-subsystem</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-wasm-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-wasm-injection</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-wasm-subsystem</artifactId>
+        </dependency>
         <!-- CDI -->
         <dependency>
             <groupId>io.smallrye.llm</groupId>
@@ -92,6 +104,23 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasm</artifactId>
         </dependency>
 
         <dependency>
@@ -268,7 +297,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-        </dependency> 
+        </dependency>
+
+        <dependency>
+            <groupId>org.extism.sdk</groupId>
+            <artifactId>chicory-sdk</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>

--- a/ai-feature-pack/src/main/resources/layers/standalone/wasm/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/wasm/layer-spec.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="wasm">
+    <props>
+        <prop name="org.wildfly.rule.class" value="org.wildfly.wasm.api.*"/>
+        <prop name="org.wildfly.rule.annotations" value="org.wildfly.wasm.api.*"/>
+    </props>
+    <dependencies>
+        <layer name="ee-concurrency"/>
+    </dependencies>
+    <feature spec="subsystem.wasm" />
+</layer-spec>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/extism/sdk/chicory-sdk/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/extism/sdk/chicory-sdk/main/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+<module name="org.extism.sdk.chicory-sdk" xmlns="urn:jboss:module:1.9">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.dylibso.chicory:log}"/>
+        <artifact name="${com.dylibso.chicory:runtime}"/>
+        <artifact name="${com.dylibso.chicory:wasi}"/>
+        <artifact name="${com.dylibso.chicory:wasm}"/>
+        <artifact name="${org.extism.sdk:chicory-sdk}"/>
+    </resources>
+    <dependencies>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="java.logging"/>
+        <module name="java.net.http"/>
+    </dependencies>
+
+</module>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
@@ -19,6 +19,7 @@
         <module name="io.smallrye.jandex"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.json.api"/>
+        <module name="org.extism.sdk.chicory-sdk"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.weld.common"/>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/wasm/injection/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/wasm/injection/main/module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.wasm.injection">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:wildfly-wasm-injection}"/>
+        <artifact name="${org.wildfly:wildfly-wasm-api}"/>
+    </resources>
+    <dependencies>
+        <module name="io.smallrye.jandex"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.json.api"/>
+        <module name="org.extism.sdk.chicory-sdk"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.weld.common"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.extension.mcp.injection" optional="true"/>
+    </dependencies>
+</module>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/wasm/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/wasm/main/module.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.wasm">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:wildfly-wasm-subsystem}"/>
+    </resources>
+
+    <dependencies>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="com.github.victools.jsonschema-generator"/>
+        <module name="io.smallrye.jandex"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.enterprise.concurrent.api"/>
+        <module name="jakarta.json.api"/>
+        <module name="java.naming"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.network"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.weld.common"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.extension.wasm.injection"/>
+        <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.service"/>
+        <module name="org.wildfly.subsystem"/>
+        <module name="org.wildfly.extension.mcp.injection" optional="true"/>
+    </dependencies>
+</module>

--- a/ai-feature-pack/wildfly-feature-pack-build.xml
+++ b/ai-feature-pack/wildfly-feature-pack-build.xml
@@ -24,6 +24,7 @@
             <standalone>
                 <extension>org.wildfly.extension.ai</extension>
                 <extension>org.wildfly.extension.mcp</extension>
+                <extension>org.wildfly.extension.wasm</extension>
             </standalone>
         </extensions>
     </generate-feature-specs>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,6 +49,18 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-wasm-api</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>io.smallrye.llm</groupId>
                 <artifactId>smallrye-llm-langchain4j-core</artifactId>
                 <version>${version.io.smallrye.llm}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>48</version>
+        <version>49</version>
     </parent>
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-ai-feature-pack-parent</artifactId>
@@ -43,8 +43,10 @@
         <version.com.azure.azure-core-http-netty>1.15.7</version.com.azure.azure-core-http-netty>
         <version.com.azure.azure-json>1.3.0</version.com.azure.azure-json>
         <version.com.azure.azure-xml>1.1.0</version.com.azure.azure-xml>
+        <version.com.dylibso.chicory>1.2.1</version.com.dylibso.chicory>
+        <version.com.fasterxml.classmate>1.7.0</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson.core>2.18.2</version.com.fasterxml.jackson.core>
-        <version.com.github.victools.jsonschema-generator>4.37.0</version.com.github.victools.jsonschema-generator>
+        <version.com.github.victools.jsonschema-generator>4.38.0</version.com.github.victools.jsonschema-generator>
         <version.com.google.apis>v1-rev20240821-2.0.0</version.com.google.apis>
         <version.com.knuddels.jtokkit>1.1.0</version.com.knuddels.jtokkit>
         <version.com.microsoft.onnxruntime>1.20.0</version.com.microsoft.onnxruntime>
@@ -58,6 +60,7 @@
         <version.io.smallrye.llm>0.0.4</version.io.smallrye.llm>
         <version.io.weaviate.client>4.9.0</version.io.weaviate.client>
         <version.net.java.dev.jna>5.13.0</version.net.java.dev.jna>
+        <version.org.extism.sdk.chicory-sdk>0.1.5</version.org.extism.sdk.chicory-sdk>
         <version.org.jetbrains.kotlin>2.1.0</version.org.jetbrains.kotlin>
         <version.org.neo4j.cypher>2024.2.0</version.org.neo4j.cypher>
         <version.org.neo4j.driver>5.26.3</version.org.neo4j.driver>
@@ -133,6 +136,39 @@
             <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-mcp-subsystem</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-wasm-api</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-wasm-injection</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-wasm-subsystem</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
                     <exclusion>
@@ -224,6 +260,54 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-xml</artifactId>
                 <version>${version.com.azure.azure-xml}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.dylibso.chicory</groupId>
+                <artifactId>log</artifactId>
+                <version>${version.com.dylibso.chicory}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.dylibso.chicory</groupId>
+                <artifactId>runtime</artifactId>
+                <version>${version.com.dylibso.chicory}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.dylibso.chicory</groupId>
+                <artifactId>wasi</artifactId>
+                <version>${version.com.dylibso.chicory}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.dylibso.chicory</groupId>
+                <artifactId>wasm</artifactId>
+                <version>${version.com.dylibso.chicory}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -645,7 +729,20 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency> 
+            </dependency>
+
+            <dependency>
+                <groupId>org.extism.sdk</groupId>
+                <artifactId>chicory-sdk</artifactId>
+                <version>${version.org.extism.sdk.chicory-sdk}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
@@ -707,7 +804,7 @@
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.5.1</version>
+                <version>${version.com.fasterxml.classmate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -816,6 +913,7 @@
     <modules>
         <module>bom</module>
         <module>wildfly-ai</module>
+        <module>wildfly-wasm</module>
         <module>wildfly-mcp</module>
         <module>ai-feature-pack</module>
     </modules>

--- a/wildfly-mcp/api/pom.xml
+++ b/wildfly-mcp/api/pom.xml
@@ -9,4 +9,14 @@
     <name>WildFly MCP Server API</name>
     <artifactId>wildfly-mcp-api</artifactId>
     <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/wildfly-mcp/injection/pom.xml
+++ b/wildfly-mcp/injection/pom.xml
@@ -41,10 +41,31 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasm</artifactId>
+        </dependency>
         <!-- CDI -->
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.extism.sdk</groupId>
+            <artifactId>chicory-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/McpPortableExtension.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/McpPortableExtension.java
@@ -21,7 +21,7 @@ public class McpPortableExtension implements Extension {
     
     private final WildFlyMCPRegistry registry;
     private final ClassLoader deploymentClassLoader;
-    
+
     public McpPortableExtension(WildFlyMCPRegistry registry, ClassLoader deploymentClassLoader) {
         this.registry = registry;
         this.deploymentClassLoader = deploymentClassLoader;

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/Capabilities.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/Capabilities.java
@@ -8,6 +8,7 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 
 public interface Capabilities {
+    public static final String MCP_CAPABILITY_NAME = "org.wildfly.ai.mcp.server";
 
     NullaryServiceDescriptor<McpEndpointConfiguration> MCP_SERVER_PROVIDER_DESCRIPTOR = NullaryServiceDescriptor.of("org.wildfly.ai.mcp.server.configuration", McpEndpointConfiguration.class);
     RuntimeCapability<Void> MCP_SERVER_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of(MCP_SERVER_PROVIDER_DESCRIPTOR).setAllowMultipleRegistrations(false).build();

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemRegistrar.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemRegistrar.java
@@ -4,11 +4,13 @@
  */
 package org.wildfly.extension.mcp;
 
+import static org.wildfly.extension.mcp.Capabilities.MCP_CAPABILITY_NAME;
 import org.wildfly.extension.mcp.deployment.McpServerCDIProcessor;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.ResourceRegistration;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -26,6 +28,7 @@ import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 class MCPSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
 
     static final String NAME = "mcp";
+    public static final RuntimeCapability<Void> MCP_CAPABILITY = RuntimeCapability.Builder.of(MCP_CAPABILITY_NAME).setAllowMultipleRegistrations(false).build();
     static final PathElement PATH = SubsystemResourceDefinitionRegistrar.pathElement(NAME);
     static final ParentResourceDescriptionResolver RESOLVER = new SubsystemResourceDescriptionResolver(NAME, MCPSubsystemRegistrar.class);
     private static final int PHASE_DEPENDENCIES_MCP = 0x1940;
@@ -43,6 +46,7 @@ class MCPSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
                     target.addDeploymentProcessor(NAME, Phase.POST_MODULE, PHASE_POST_MODULE_MCP, new McpServerCDIProcessor());
                     target.addDeploymentProcessor(NAME, Phase.INSTALL, PHASE_INSTALL_MCP, new McpServerDeploymentProcessor());
                 })
+                .addCapability(MCP_CAPABILITY)
                 .build();
         ManagementResourceRegistrar.of(descriptor).register(registration);
         new McpEndpointConfigurationProviderRegistrar(RESOLVER).register(registration, context);

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerCDIProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerCDIProcessor.java
@@ -23,10 +23,10 @@ public class McpServerCDIProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        WildFlyMCPRegistry registry = deploymentUnit.getAttachment(MCPAttachements.MCP_REGISTRY_METADATA);
         final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         final org.jboss.modules.Module module = deploymentUnit.getAttachment(Attachments.MODULE);
         final ClassLoader classLoader = module.getClassLoader();
+        WildFlyMCPRegistry registry = deploymentUnit.getAttachment(MCPAttachements.MCP_REGISTRY_METADATA);
         final Optional<WeldCapability> weldCapability = support.getOptionalCapabilityRuntimeAPI(WELD_CAPABILITY_NAME, WeldCapability.class);
         if (weldCapability != null && weldCapability.isPresent() && !weldCapability.get().isPartOfWeldDeployment(deploymentUnit)) {
             ROOT_LOGGER.cdiRequired();

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerDependencyProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/McpServerDependencyProcessor.java
@@ -82,13 +82,13 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
             }
             MCPLogger.ROOT_LOGGER.debug("Prompt detected on class " + info.declaringClass() + " with method " + info.name() + " with the following annotated parameters " + arguments);
             McpFeatureMetadata metadata = new McpFeatureMetadata(McpFeatureMetadata.Kind.PROMPT,
-                    name, 
+                    name,
                     new MethodMetadata(
                             annotation.target().asMethod().name(),
                             description,
                             null,
                             null,
-                            arguments, 
+                            arguments,
                             info.declaringClass().toString(),
                             annotation.target().asMethod().returnType().name().toString())
             );
@@ -96,7 +96,7 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
         }
     }
 
-    private void processTools(WildFlyMCPRegistry registry,  List<AnnotationInstance> annotations) {
+    private void processTools(WildFlyMCPRegistry registry, List<AnnotationInstance> annotations) {
         if (annotations == null || annotations.isEmpty()) {
             return;
         }
@@ -117,13 +117,13 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
             }
             MCPLogger.ROOT_LOGGER.debug("Tool detected on class " + info.declaringClass() + " with method " + info.name() + " with the following annotated parameters " + arguments);
             McpFeatureMetadata metadata = new McpFeatureMetadata(McpFeatureMetadata.Kind.TOOL,
-                    name, 
+                    name,
                     new MethodMetadata(
                             annotation.target().asMethod().name(),
                             description,
                             null,
                             null,
-                            arguments, 
+                            arguments,
                             info.declaringClass().toString(),
                             annotation.target().asMethod().returnType().name().toString())
             );
@@ -131,7 +131,7 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
         }
     }
 
-    private void processResources(WildFlyMCPRegistry registry,  List<AnnotationInstance> annotations) {
+    private void processResources(WildFlyMCPRegistry registry, List<AnnotationInstance> annotations) {
         if (annotations == null || annotations.isEmpty()) {
             return;
         }
@@ -154,13 +154,13 @@ public class McpServerDependencyProcessor implements DeploymentUnitProcessor {
             }
             MCPLogger.ROOT_LOGGER.debug("Resource detected on class " + info.declaringClass() + " with method " + info.name() + " with the following annotated parameters " + arguments);
             McpFeatureMetadata metadata = new McpFeatureMetadata(McpFeatureMetadata.Kind.RESOURCE,
-                    name, 
+                    name,
                     new MethodMetadata(
                             annotation.target().asMethod().name(),
                             description,
                             uri,
                             mimeType,
-                            arguments, 
+                            arguments,
                             info.declaringClass().toString(),
                             annotation.target().asMethod().returnType().name().toString())
             );

--- a/wildfly-mcp/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/wildfly-mcp/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,1 +1,1 @@
-org.wildfly.extension.ai.AIExtensionTransformerRegistration
+org.wildfly.extension.mcp.MCPExtensionTransformerRegistration

--- a/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
+++ b/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
@@ -27,21 +27,21 @@
                 The MCP subsystem root type.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice minOccurs="0" maxOccurs="1">
-            <xs:element name="mcp-server" type="mcpServerType">
+        <xs:sequence>
+            <xs:element name="mcp-server" type="mcpServerType"  minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        The MCP server.
+                        The MCP server configuration.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-        </xs:choice>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="mcpServerType">
         <xs:annotation>
             <xs:documentation>
-                The MCP.
+                The MCP endpoints.
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="name" type="xs:string" use="required">

--- a/wildfly-wasm/api/pom.xml
+++ b/wildfly-wasm/api/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-wasm</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <name>WildFly WASM Server API</name>
+    <artifactId>wildfly-wasm-api</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/DefaultWasmTools.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/DefaultWasmTools.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class DefaultWasmTools<T> extends WasmTools<T> {
+
+    public DefaultWasmTools(WasmToolContext context) {
+        super(context);
+    }
+
+    @Override
+    public T build() {
+        Object proxyInstance = Proxy.newProxyInstance(
+                context.wasmToolClass().getClassLoader(),
+                new Class<?>[]{context.wasmToolClass()},
+                new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if(args == null && "toString".equals(method.getName())) {
+                    return null;
+                }
+                byte[] input  = context.wasmArgumentSerializer().serialize(args);
+                return context.wasmResultDeserializer().deserialize(context.wasmInvoker().call(context.methodName(method), input));
+            }
+        });
+        return (T)proxyInstance;
+    }
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmArgumentSerializer.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmArgumentSerializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+@FunctionalInterface
+public interface WasmArgumentSerializer {
+
+    byte[] serialize(Object[] args);
+
+    WasmArgumentSerializer DEFAULT = (Object[] args) -> {
+        if (args == null) {
+            return null;
+        }
+        if (args[0] instanceof String string) {
+            return string.getBytes(StandardCharsets.UTF_8);
+        }
+        if (args[0] instanceof byte[] bs) {
+            return bs;
+        }
+        return Arrays.toString(args).getBytes(StandardCharsets.UTF_8);
+    };
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmInvoker.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmInvoker.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+public interface WasmInvoker {
+
+    public byte[] call(String method, byte[] input);
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmResultDeserializer.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmResultDeserializer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import java.nio.charset.StandardCharsets;
+
+@FunctionalInterface
+public interface WasmResultDeserializer {
+
+    Object deserialize(byte[] result);
+    WasmResultDeserializer DEFAULT = (byte[] result) -> {
+        return new String(result, StandardCharsets.UTF_8);
+    };
+    
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmTool.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmTool.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(ElementType.FIELD)
+public @interface WasmTool {
+
+    public String value() default "";
+
+    public final class WasmToolLiteral extends AnnotationLiteral<WasmTool> implements WasmTool {
+
+        private final String value;
+
+        /**
+         * Default Singleton literal
+         *
+         * @param value
+         * @return
+         */
+        public static WasmToolLiteral of(String value) {
+            return new WasmToolLiteral(value);
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        private WasmToolLiteral(String value) {
+            this.value = value;
+        }
+        private static final long serialVersionUID = 1L;
+
+    }
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmToolContext.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmToolContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import java.lang.reflect.Method;
+
+public class WasmToolContext {
+
+    private final Class<?> wasmToolClass;
+    private final String methodName;
+    private final WasmArgumentSerializer wasmArgumentSerializer;
+    private final WasmResultDeserializer wasmResultDeserializer;
+    private WasmInvoker invoker;
+
+    public WasmToolContext(Class<?> wasmToolClass, String methodName, WasmArgumentSerializer wasmArgumentSerializer,
+            WasmResultDeserializer wasmResultDeserializer) {
+        this.wasmToolClass = wasmToolClass;
+        this.methodName = methodName;
+        this.wasmArgumentSerializer = wasmArgumentSerializer;
+        this.wasmResultDeserializer = wasmResultDeserializer;
+    }
+
+    String methodName(Method method) {
+        if(this.methodName != null && ! this.methodName.isBlank() && ! "#default".equals(this.methodName)) {
+        return this.methodName;
+        }
+        return method.getName();
+    }
+
+    WasmArgumentSerializer wasmArgumentSerializer() {
+        return this.wasmArgumentSerializer;
+    }
+
+    WasmResultDeserializer wasmResultDeserializer() {
+        return this.wasmResultDeserializer;
+    }
+
+    Class<?> wasmToolClass() {
+        return this.wasmToolClass;
+    }
+    public void wasmInvoker(WasmInvoker invoker) {
+        this.invoker = invoker;
+    }
+    public WasmInvoker wasmInvoker() {
+        return this.invoker;
+    }
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmToolService.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmToolService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.inject.Stereotype;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+@Stereotype
+public  @interface WasmToolService {
+
+    String wasmToolConfigurationName() default "#default";
+    String wasmMethodName() default "#default";
+    Class<? extends WasmArgumentSerializer> argumentSerializer() default WasmArgumentSerializer.class;
+    Class<? extends WasmResultDeserializer> resultDeserializer() default WasmResultDeserializer.class;
+
+}

--- a/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmTools.java
+++ b/wildfly-wasm/api/src/main/java/org/wildfly/wasm/api/WasmTools.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.wasm.api;
+
+public abstract class WasmTools<T> {
+    protected final WasmToolContext context;
+
+    public WasmTools(WasmToolContext context) {
+        this.context = context;
+    }
+
+    public static <T> T create(Class<T> wasmTool, String methodName, WasmArgumentSerializer wasmArgumentSerializer, 
+            WasmResultDeserializer wasmResultDeserializer, WasmInvoker invoker) {
+        return builder(wasmTool, methodName, wasmArgumentSerializer, wasmResultDeserializer)
+                .wasmInvoker(invoker)
+                .build();
+    }
+
+    public static <T> WasmTools<T> builder(Class<T> wasmTool, String methodName, WasmArgumentSerializer wasmArgumentSerializer, 
+            WasmResultDeserializer wasmResultDeserializer) {
+        WasmToolContext context = new WasmToolContext(wasmTool, methodName, wasmArgumentSerializer, wasmResultDeserializer);
+        return new DefaultWasmTools<>(context);
+    }
+
+    public WasmTools<T> wasmInvoker(WasmInvoker invoker) {
+        context.wasmInvoker(invoker);
+        return this;
+    }
+
+    public abstract T build();
+}

--- a/wildfly-wasm/injection/pom.xml
+++ b/wildfly-wasm/injection/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-wasm</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-wasm-injection</artifactId>
+    <name>WildFly: WASM Server Injection</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-mcp-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-wasm-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-wasm-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-weld-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>wasm</artifactId>
+        </dependency>
+        <!-- CDI -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.extism.sdk</groupId>
+            <artifactId>chicory-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/ChicoryLogger.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/ChicoryLogger.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.wasm.injection;
+
+import static com.dylibso.chicory.log.Logger.Level.ALL;
+import static com.dylibso.chicory.log.Logger.Level.DEBUG;
+import static com.dylibso.chicory.log.Logger.Level.ERROR;
+import static com.dylibso.chicory.log.Logger.Level.INFO;
+import static com.dylibso.chicory.log.Logger.Level.OFF;
+import static com.dylibso.chicory.log.Logger.Level.TRACE;
+import static com.dylibso.chicory.log.Logger.Level.WARNING;
+
+
+public class ChicoryLogger implements com.dylibso.chicory.log.Logger {
+    static final ChicoryLogger ROOT_LOGGER = new ChicoryLogger();
+
+    @Override
+    public void log(Level level, String msg, Throwable throwable) {
+        if(OFF == level) {
+            return;
+        }
+        if(ALL == level) {
+            WASMLogger.ROOT_LOGGER.debug(msg, throwable);
+        } else {
+            WASMLogger.ROOT_LOGGER.log(getLevel(level), msg, throwable);
+        }
+    }
+
+    @Override
+    public boolean isLoggable(Level level) {
+        if(OFF == level) {
+            return false;
+        }
+        org.jboss.logging.Logger.Level realLevel ;
+        switch(level) {
+            case ALL -> {
+                return true;
+            }
+            case DEBUG -> realLevel = org.jboss.logging.Logger.Level.DEBUG;
+            case ERROR -> realLevel = org.jboss.logging.Logger.Level.ERROR;
+            case INFO -> realLevel = org.jboss.logging.Logger.Level.INFO;
+            case OFF -> {
+                return false;
+            }
+            case TRACE -> realLevel = org.jboss.logging.Logger.Level.TRACE;
+            case WARNING -> realLevel = org.jboss.logging.Logger.Level.WARN;
+            default -> realLevel = org.jboss.logging.Logger.Level.INFO;
+        }
+        return WASMLogger.ROOT_LOGGER.isEnabled(realLevel);
+    }
+
+    private org.jboss.logging.Logger.Level getLevel(Level level) {
+        return switch (level) {
+            case ALL -> org.jboss.logging.Logger.Level.TRACE;
+            case DEBUG -> org.jboss.logging.Logger.Level.DEBUG;
+            case ERROR -> org.jboss.logging.Logger.Level.ERROR;
+            case INFO -> org.jboss.logging.Logger.Level.INFO;
+            case OFF -> org.jboss.logging.Logger.Level.ERROR;
+            case TRACE -> org.jboss.logging.Logger.Level.TRACE;
+            case WARNING -> org.jboss.logging.Logger.Level.WARN;
+            default -> org.jboss.logging.Logger.Level.INFO;
+        };
+    }
+}

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WASMLogger.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WASMLogger.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.wasm.injection;
+
+import java.lang.invoke.MethodHandles;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "WFMCPINJC", length = 5)
+public interface WASMLogger extends BasicLogger {
+
+    WASMLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WASMLogger.class, "org.wildfly.extension.mcp.injection");
+
+    @Message(id = 1, value = "The bean name %s is expecting a %s while the llm is configured as streaming %s")
+    IllegalStateException incorrectLLMConfiguration(String name, String typeClass, boolean streaming);
+
+}

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmPortableExtension.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmPortableExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.injection;
+
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import java.util.Map;
+import org.wildfly.wasm.api.WasmInvoker;
+import org.wildfly.wasm.api.WasmTool.WasmToolLiteral;
+
+public class WasmPortableExtension implements Extension {
+
+    private final WildFlyWasmRegistry registry;
+
+    public WasmPortableExtension(WildFlyWasmRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void atd(@Observes AfterBeanDiscovery atd) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException {
+        for (Map.Entry<String, WasmToolConfiguration> entry : registry.listWasmTools().entrySet()) {
+            atd.addBean()
+                    .scope(ApplicationScoped.class)
+                    .addQualifiers(WasmToolLiteral.of(entry.getKey()))
+                    .types(WasmInvoker.class)
+                    .produceWith(c -> entry.getValue().create());
+            WASMLogger.ROOT_LOGGER.info(entry.getKey() + " should be discoverable by CDI as a WASM Tool");
+        }
+    }
+}

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmServicePortableExtension.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmServicePortableExtension.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.injection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.WithAnnotations;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.wildfly.wasm.api.WasmArgumentSerializer;
+import org.wildfly.wasm.api.WasmInvoker;
+import org.wildfly.wasm.api.WasmResultDeserializer;
+import org.wildfly.wasm.api.WasmTool.WasmToolLiteral;
+import org.wildfly.wasm.api.WasmToolService;
+import org.wildfly.wasm.api.WasmTools;
+
+public class WasmServicePortableExtension implements Extension {
+
+    private static final Set<Class<?>> detectedWasmServicesDeclaredInterfaces = new HashSet<>();
+    private final Set<Annotation> qualifiers;
+
+    public WasmServicePortableExtension(Annotation... qualifiers) {
+        this.qualifiers = new HashSet<>();
+        this.qualifiers.add(Default.Literal.INSTANCE);
+        this.qualifiers.addAll(Arrays.asList(qualifiers));
+    }
+
+    <T> void processAnnotatedType(@Observes @WithAnnotations({WasmToolService.class}) ProcessAnnotatedType<T> pat) {
+        if (pat.getAnnotatedType().getJavaClass().isInterface()) {
+            detectedWasmServicesDeclaredInterfaces.add(pat.getAnnotatedType().getJavaClass());
+        } else {
+            System.out.println("processAnnotatedType reject " + pat.getAnnotatedType().getJavaClass().getName()
+                    + " which is not an interface");
+            pat.veto();
+        }
+    }
+
+    public void atd(@Observes AfterBeanDiscovery atd) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InstantiationException, IllegalArgumentException, InvocationTargetException {
+        for (Class<?> wasmToolServiceClass : detectedWasmServicesDeclaredInterfaces) {
+            System.out.println("afterBeanDiscovery create synthetic:  " + wasmToolServiceClass.getName() + " " + wasmToolServiceClass.getClassLoader());
+            Class<? extends WasmArgumentSerializer> wasmArgumentSerializerClass = wasmToolServiceClass.getAnnotation(WasmToolService.class).argumentSerializer();
+            final WasmArgumentSerializer wasmArgumentSerializer;
+            if (wasmArgumentSerializerClass != null && !wasmArgumentSerializerClass.isInterface()) {
+                wasmArgumentSerializer = wasmArgumentSerializerClass.getConstructor(new Class<?>[0]).newInstance(new Object[0]);
+            } else {
+                wasmArgumentSerializer = WasmArgumentSerializer.DEFAULT;
+            }
+            Class<? extends WasmResultDeserializer> wasmResultDeserializerClass = wasmToolServiceClass.getAnnotation(WasmToolService.class).resultDeserializer();
+            final WasmResultDeserializer wasmResultDeserializer;
+            if (wasmResultDeserializerClass != null && !wasmResultDeserializerClass.isInterface()) {
+                wasmResultDeserializer = wasmResultDeserializerClass.getConstructor(new Class<?>[0]).newInstance(new Object[0]);
+            } else {
+                wasmResultDeserializer = WasmResultDeserializer.DEFAULT;
+            }
+            atd.addBean()
+                    .scope(ApplicationScoped.class)
+                    .addQualifiers(qualifiers)
+                    .beanClass(wasmToolServiceClass)
+                    .types(wasmToolServiceClass)
+                    .produceWith(lookup -> {
+                        String invokerName = wasmToolServiceClass.getAnnotation(WasmToolService.class).wasmToolConfigurationName();
+                        String methodName = wasmToolServiceClass.getAnnotation(WasmToolService.class).wasmMethodName();
+                        WasmInvoker invoker = lookup.select(WasmInvoker.class, WasmToolLiteral.of(invokerName)).get();
+                        return WasmTools.create(wasmToolServiceClass, methodName, wasmArgumentSerializer, wasmResultDeserializer, invoker);
+                    });
+        }
+    }
+}

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmToolConfiguration.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WasmToolConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.injection;
+
+import java.nio.file.Path;
+import java.util.Map;
+import org.extism.sdk.chicory.Manifest;
+import org.extism.sdk.chicory.ManifestWasm;
+import org.extism.sdk.chicory.Plugin;
+import org.wildfly.wasm.api.WasmInvoker;
+
+public class WasmToolConfiguration {
+
+    private final String name;
+    private final Path wasmFile;
+    private final String allowedHosts;
+    private final Map<String, String> config;
+
+    public WasmToolConfiguration(String name, Path wasmFile, Map<String, String> config) {
+        this.name = name;
+        this.wasmFile = wasmFile;
+        this.config = config;
+        this.allowedHosts = "*";
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public WasmInvoker create() {
+        ManifestWasm wasm = ManifestWasm.fromFilePath(wasmFile).build();
+        Manifest manifest = Manifest.ofWasms(wasm)
+                .withOptions(new Manifest.Options().withAllowedHosts(allowedHosts).withConfig(config)).build();
+        final Plugin plugin = Plugin.ofManifest(manifest).withLogger(ChicoryLogger.ROOT_LOGGER).build();
+        return new WasmInvoker() {
+            @Override
+            public byte[] call(String method, byte[] input) {
+                return plugin.call(method, input);
+            }
+        };
+    }
+}

--- a/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WildFlyWasmRegistry.java
+++ b/wildfly-wasm/injection/src/main/java/org/wildfly/extension/wasm/injection/WildFlyWasmRegistry.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.injection;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WildFlyWasmRegistry {
+
+    private final Map<String, WasmToolConfiguration> wasmTools = new HashMap<>();
+
+    public void registerWasmTool(WasmToolConfiguration wasmToolConfiguration) {
+        wasmTools.put(wasmToolConfiguration.name(), wasmToolConfiguration);
+    }
+
+    public Map<String, WasmToolConfiguration> listWasmTools() {
+        return Collections.unmodifiableMap(wasmTools);
+    }
+
+}

--- a/wildfly-wasm/injection/src/main/resources/META-INF/beans.xml
+++ b/wildfly-wasm/injection/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/wildfly-wasm/pom.xml
+++ b/wildfly-wasm/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ai-feature-pack-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-wasm</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>WildFly WASM Server Extension</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>api</module>
+        <module>injection</module>
+        <module>subsystem</module>
+    </modules>
+
+</project>

--- a/wildfly-wasm/subsystem/pom.xml
+++ b/wildfly-wasm/subsystem/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-wasm</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-wasm-subsystem</artifactId>
+    <name>WildFly: WASM Server Subsystem</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem</artifactId>
+        </dependency>
+        <!-- CDI -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-weld-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-wasm-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-wasm-injection</artifactId>
+        </dependency>
+
+        <!-- CDI -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-undertow</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-clustering-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-generator</artifactId>
+        </dependency> 
+        <dependency>
+            <groupId>com.fasterxml</groupId>
+            <artifactId>classmate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/Capabilities.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/Capabilities.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.wildfly.extension.wasm.injection.WasmToolConfiguration;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+
+public interface Capabilities {
+    String MCP_CAPABILITY_NAME = "org.wildfly.ai.mcp.server";
+    UnaryServiceDescriptor<WasmToolConfiguration> WASM_TOOL_PROVIDER_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ai.mcp.server.wasm.tool", WasmToolConfiguration.class);
+    RuntimeCapability<Void> WASM_TOOL_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of(WASM_TOOL_PROVIDER_DESCRIPTOR).setAllowMultipleRegistrations(true).build();
+
+    String UNDERTOW_HOST_CAPABILITY_NAME = "org.wildfly.undertow.host";
+    String UNDERTOW_SERVER_CAPABILITY_NAME = "org.wildfly.undertow.server";
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmExtension.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmExtension.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.wasm;
+
+import org.wildfly.subsystem.SubsystemConfiguration;
+import org.wildfly.subsystem.SubsystemExtension;
+import org.wildfly.subsystem.SubsystemPersistence;
+
+/**
+ * The extension class for the WildFly MCP extension.
+ */
+public class WasmExtension extends SubsystemExtension<WasmSubsystemSchema> {
+
+    public WasmExtension() {
+        super(SubsystemConfiguration.of(WasmSubsystemRegistrar.NAME, WasmSubsystemModel.CURRENT, WasmSubsystemRegistrar::new), SubsystemPersistence.of(WasmSubsystemSchema.CURRENT));
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmExtensionTransformerRegistration.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmExtensionTransformerRegistration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.wasm;
+
+import java.util.EnumSet;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.description.TransformationDescription;
+
+/**
+ * Transformer registration for AI extension.
+ */
+public class WasmExtensionTransformerRegistration implements ExtensionTransformerRegistration {
+
+    @Override
+    public String getSubsystemName() {
+        return WasmSubsystemRegistrar.NAME;
+    }
+
+    @Override
+    public void registerTransformers(SubsystemTransformerRegistration registration) {
+        for (WasmSubsystemModel model : EnumSet.complementOf(EnumSet.of(WasmSubsystemModel.CURRENT))) {
+            ModelVersion version = model.getVersion();
+            TransformationDescription.Tools.register(new WasmSubsystemTransformation().apply(version), registration, version);
+        }
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmLogger.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmLogger.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.mcp;
+
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
+
+import java.lang.invoke.MethodHandles;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "WFMCP", length = 5)
+public interface WasmLogger extends BasicLogger {
+
+    WasmLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WasmLogger.class, "org.wildfly.extension.mcp");
+
+    @LogMessage(level = WARN)
+    @Message(id = 1, value = "The deployment does not have Jakarta Dependency Injection enabled.")
+    void cdiRequired();
+
+    @Message(id = 2, value = "Unable to resolve annotation index for deployment unit: %s")
+    DeploymentUnitProcessingException unableToResolveAnnotationIndex(DeploymentUnit deploymentUnit);
+
+    @Message(id = 3, value = "Couldn't access the Chat Language Model called %s")
+    OperationFailedException chatLanguageModelServiceUnavailable(String chatLanguageModelName);
+    
+    @LogMessage(level = INFO)
+    @Message(id = 4, value = "Registered MicroProfile OpenAPI endpoint '%s' for host '%s'")
+    void endpointRegistered(String path, String hostName);
+
+    @LogMessage(level = INFO)
+    @Message(id = 5, value = "Unregistered MicroProfile OpenAPI endpoint '%s' for host '%s'")
+    void endpointUnregistered(String path, String hostName);
+
+    @Message(id = 6, value = "Failed to resolve module for deployment %s")
+    DeploymentUnitProcessingException failedToResolveModule(DeploymentUnit deploymentUnit);
+
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderRegistrar.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderRegistrar.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILESYSTEM_PATH;
+
+import java.util.Collection;
+import java.util.List;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.ResourceRegistration;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
+import org.wildfly.subsystem.resource.ResourceDescriptor;
+import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
+
+public class WasmProviderRegistrar implements ChildResourceDefinitionRegistrar {
+
+    protected static final SimpleAttributeDefinition WASM_PATH
+            = new SimpleAttributeDefinitionBuilder("path", ModelType.STRING, false)
+                    .setXmlName("path")
+                    .setAllowExpression(true)
+                    .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+                    .addArbitraryDescriptor(FILESYSTEM_PATH, ModelNode.TRUE)
+                    .build();
+    protected static final SimpleAttributeDefinition WASM_RELATIVE_TO
+            = new SimpleAttributeDefinitionBuilder("relative-to", ModelType.STRING, true)
+                    .setXmlName("relative-to")
+                    .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+                    .setCapabilityReference(PathManager.PATH_SERVICE_DESCRIPTOR.getName())
+                    .build();
+
+    public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(
+            WASM_PATH, WASM_RELATIVE_TO);
+
+    static final String WASM_TOOL = "wasm-tool";
+
+    private final ResourceRegistration registration;
+    private final ResourceDescriptor descriptor;
+    public static final PathElement PATH = PathElement.pathElement(WASM_TOOL);
+
+    public WasmProviderRegistrar(ParentResourceDescriptionResolver parentResolver) {
+        this.registration = ResourceRegistration.of(PATH);
+        this.descriptor = ResourceDescriptor.builder(parentResolver.createChildResolver(PATH))
+                .addCapability(Capabilities.WASM_TOOL_PROVIDER_CAPABILITY)
+                .addAttributes(ATTRIBUTES)
+                .withRuntimeHandler(ResourceOperationRuntimeHandler.configureService(new WasmProviderServiceConfigurator()))
+                .build();
+    }
+
+    @Override
+    public ManagementResourceRegistration register(ManagementResourceRegistration parent, ManagementResourceRegistrationContext mrrc) {
+        ResourceDefinition definition = ResourceDefinition.builder(this.registration, this.descriptor.getResourceDescriptionResolver()).build();
+        ManagementResourceRegistration resourceRegistration = parent.registerSubModel(definition);
+        ManagementResourceRegistrar.of(this.descriptor).register(resourceRegistration);
+        return resourceRegistration;
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderServiceConfigurator.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderServiceConfigurator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import static org.wildfly.extension.wasm.Capabilities.WASM_TOOL_PROVIDER_CAPABILITY;
+import static org.wildfly.extension.wasm.WasmProviderRegistrar.WASM_PATH;
+import static org.wildfly.extension.wasm.WasmProviderRegistrar.WASM_RELATIVE_TO;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.function.Supplier;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.wasm.injection.WasmToolConfiguration;
+import org.wildfly.subsystem.service.ResourceServiceConfigurator;
+import org.wildfly.subsystem.service.ResourceServiceInstaller;
+import org.wildfly.subsystem.service.ServiceDependency;
+import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
+
+public class WasmProviderServiceConfigurator implements ResourceServiceConfigurator {
+
+    @Override
+    public ResourceServiceInstaller configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        final String path = WASM_PATH.resolveModelAttribute(context, model).asString();
+        final String relativeTo = WASM_RELATIVE_TO.resolveModelAttribute(context, model).asStringOrNull();
+        final String name = context.getCurrentAddressValue();
+        ServiceDependency<PathManager> pathManager = ServiceDependency.on(PathManager.SERVICE_DESCRIPTOR);
+        Supplier<WasmToolConfiguration> factory = new Supplier<>() {
+            @Override
+            public WasmToolConfiguration get() {
+                Path wasmFile = new File(pathManager.get().resolveRelativePathEntry(path, relativeTo)).toPath();
+                return new WasmToolConfiguration(name, wasmFile, Collections.emptyMap());
+            }
+        };
+        return CapabilityServiceInstaller.builder(WASM_TOOL_PROVIDER_CAPABILITY, factory)
+                .requires(pathManager)
+                .asActive()
+                .build();
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemModel.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemModel.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.wasm;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.SubsystemModel;
+
+/**
+ * Enumeration of MCP subsystem model versions.
+ */
+enum WasmSubsystemModel implements SubsystemModel {
+    VERSION_1_0_0(1, 0, 0),
+    ;
+    static final WasmSubsystemModel CURRENT = VERSION_1_0_0;
+
+    private final ModelVersion version;
+
+    WasmSubsystemModel(int major, int minor, int micro) {
+        this.version = ModelVersion.create(major, minor, micro);
+    }
+
+    @Override
+    public ModelVersion getVersion() {
+        return this.version;
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemRegistrar.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemRegistrar.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.ResourceRegistration;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.server.deployment.Phase;
+import org.wildfly.extension.wasm.deployment.WasmCDIProcessor;
+import org.wildfly.extension.wasm.deployment.WasmDependencyProcessor;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
+import org.wildfly.subsystem.resource.ResourceDescriptor;
+import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
+
+/**
+ * Registrar for the MCP subsystem.
+ */
+class WasmSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
+
+    static final String NAME = "wasm";
+    static final PathElement PATH = SubsystemResourceDefinitionRegistrar.pathElement(NAME);
+    static final ParentResourceDescriptionResolver RESOLVER = new SubsystemResourceDescriptionResolver(NAME, WasmSubsystemRegistrar.class);
+    private static final int PHASE_DEPENDENCIES_WASM = 0x1950;
+    private static final int PHASE_POST_MODULE_WASM = 0x3850;
+
+    @Override
+    public ManagementResourceRegistration register(SubsystemRegistration parent, ManagementResourceRegistrationContext context) {
+        parent.setHostCapable();
+        ManagementResourceRegistration registration = parent.registerSubsystemModel(ResourceDefinition.builder(ResourceRegistration.of(PATH), RESOLVER).build());
+        ResourceDescriptor descriptor = ResourceDescriptor
+                .builder(RESOLVER)
+                .withDeploymentChainContributor(target -> {
+                    target.addDeploymentProcessor(NAME, Phase.DEPENDENCIES, PHASE_DEPENDENCIES_WASM, new WasmDependencyProcessor());
+                    target.addDeploymentProcessor(NAME, Phase.POST_MODULE, PHASE_POST_MODULE_WASM, new WasmCDIProcessor());
+                })
+                .build();
+        ManagementResourceRegistrar.of(descriptor).register(registration);
+        new WasmProviderRegistrar(RESOLVER).register(registration, context);
+        return registration;
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemSchema.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemSchema.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentSubsystemSchema;
+import org.jboss.as.controller.SubsystemSchema;
+import org.jboss.as.controller.xml.VersionedNamespace;
+import org.jboss.staxmapper.IntVersion;
+
+/**
+ * Enumeration of AI subsystem schema versions.
+ */
+enum WasmSubsystemSchema implements PersistentSubsystemSchema<WasmSubsystemSchema> {
+    VERSION_1_0(1, 0),;
+    static final WasmSubsystemSchema CURRENT = VERSION_1_0;
+
+    private final VersionedNamespace<IntVersion, WasmSubsystemSchema> namespace;
+
+    WasmSubsystemSchema(int major, int minor) {
+        this.namespace = SubsystemSchema.createLegacySubsystemURN(WasmSubsystemRegistrar.NAME, new IntVersion(major, minor));
+    }
+
+    @Override
+    public VersionedNamespace<IntVersion, WasmSubsystemSchema> getNamespace() {
+        return this.namespace;
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getXMLDescription() {
+        PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
+        return factory.builder(WasmSubsystemRegistrar.PATH)
+                .addChild(factory.builder(WasmProviderRegistrar.PATH).addAttributes(WasmProviderRegistrar.ATTRIBUTES.stream()).build())
+                .build();
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemTransformation.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemTransformation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import java.util.function.Function;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescription;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+
+/**
+ * Creates the transformation descriptions for the MCP subsystem resource.
+ */
+public class WasmSubsystemTransformation implements Function<ModelVersion, TransformationDescription> {
+
+    private final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+
+    @Override
+    public TransformationDescription apply(ModelVersion version) {
+        return this.builder.build();
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmAttachements.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmAttachements.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.deployment;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.AttachmentList;
+import org.wildfly.extension.wasm.injection.WasmToolConfiguration;
+
+public class WasmAttachements {
+    static final AttachmentKey<AttachmentList<String>> WASM_TOOL_NAMES = AttachmentKey.createList(String.class);
+    static final AttachmentKey<AttachmentList<WasmToolConfiguration>> WASM_TOOL_CONFIGURATIONS = AttachmentKey.createList(WasmToolConfiguration.class);
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmCDIProcessor.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmCDIProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.deployment;
+
+import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
+import static org.wildfly.extension.mcp.WasmLogger.ROOT_LOGGER;
+
+import static org.wildfly.extension.wasm.Capabilities.MCP_CAPABILITY_NAME;
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.weld.WeldCapability;
+import org.wildfly.extension.mcp.WasmLogger;
+import org.wildfly.extension.wasm.injection.WasmPortableExtension;
+import org.wildfly.extension.wasm.injection.WasmServicePortableExtension;
+import org.wildfly.extension.wasm.injection.WildFlyWasmRegistry;
+
+public class WasmCDIProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+        WildFlyWasmRegistry wasmRegistry = new WildFlyWasmRegistry();
+        deploymentUnit.getAttachmentList(WasmAttachements.WASM_TOOL_CONFIGURATIONS).forEach(c -> wasmRegistry.registerWasmTool(c));
+        final Optional<WeldCapability> weldCapability = support.getOptionalCapabilityRuntimeAPI(WELD_CAPABILITY_NAME, WeldCapability.class);
+        if (weldCapability != null && weldCapability.isPresent() && !weldCapability.get().isPartOfWeldDeployment(deploymentUnit)) {
+            ROOT_LOGGER.cdiRequired();
+        } else {
+            weldCapability.get().registerExtensionInstance(new WasmPortableExtension(wasmRegistry), deploymentUnit);
+            if (support.hasCapability(MCP_CAPABILITY_NAME)) {
+                try {
+                    Annotation mcpToolQualifier = Annotation.class.cast(Class.forName("org.wildfly.extension.mcp.injection.tool.McpTool$McpToolLiteral").getDeclaredField("INSTANCE").get(null));
+                    weldCapability.get().registerExtensionInstance(new WasmServicePortableExtension(mcpToolQualifier), deploymentUnit);
+                } catch (ClassNotFoundException | NoSuchFieldException |SecurityException | IllegalAccessException | IllegalArgumentException ex) {
+                    WasmLogger.ROOT_LOGGER.error(ex);
+                    weldCapability.get().registerExtensionInstance(new WasmServicePortableExtension(), deploymentUnit);
+                }
+            } else {
+                weldCapability.get().registerExtensionInstance(new WasmServicePortableExtension(), deploymentUnit);
+            }
+        }
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmDependencyProcessor.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmDependencyProcessor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm.deployment;
+
+import static org.wildfly.extension.mcp.WasmLogger.ROOT_LOGGER;
+import static org.wildfly.extension.wasm.Capabilities.WASM_TOOL_PROVIDER_CAPABILITY;
+import java.util.List;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.annotation.CompositeIndex;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+import org.jboss.modules.ModuleLoader;
+import org.wildfly.wasm.api.WasmTool;
+import org.wildfly.wasm.api.WasmToolService;
+
+public class WasmDependencyProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext deploymentPhaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = deploymentPhaseContext.getDeploymentUnit();
+        ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+        ModuleLoader moduleLoader = org.jboss.modules.Module.getBootModuleLoader();
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "jakarta.json.api").setOptional(false).setImportServices(true).build());
+        ModuleDependency modDep = ModuleDependency.Builder.of(moduleLoader, "org.wildfly.extension.wasm.injection").setOptional(false).setExport(true).setImportServices(true).build();
+        modDep.addImportFilter(s -> s.equals("META-INF"), true);
+        moduleSpecification.addSystemDependency(modDep);
+        final CompositeIndex index = deploymentUnit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX);
+        if (index == null) {
+            throw ROOT_LOGGER.unableToResolveAnnotationIndex(deploymentUnit);
+        }
+        List<AnnotationInstance> annotations = index.getAnnotations(DotName.createSimple(WasmTool.class));
+        processWasmTools(deploymentPhaseContext, annotations);
+        annotations = index.getAnnotations(DotName.createSimple(WasmToolService.class));
+        processWasmToolServices(deploymentPhaseContext, annotations);
+    }
+
+    private void processWasmTools(DeploymentPhaseContext deploymentPhaseContext, List<AnnotationInstance> annotations) {
+        if (annotations == null || annotations.isEmpty()) {
+            return;
+        }
+        DeploymentUnit deploymentUnit = deploymentPhaseContext.getDeploymentUnit();
+        for (AnnotationInstance annotation : annotations) {
+            String name;
+            if(annotation.value("name") != null) {
+                name = annotation.value("name").asString();
+            }else {
+                if(annotation.target().kind() == Kind.FIELD) {
+                   name = annotation.target().asField().name();
+                } else {
+                    name = annotation.target().asMethodParameter().name();
+                }
+            }
+            deploymentUnit.addToAttachmentList(WasmAttachements.WASM_TOOL_NAMES, name);
+            deploymentPhaseContext.addDeploymentDependency(WASM_TOOL_PROVIDER_CAPABILITY.getCapabilityServiceName(name), WasmAttachements.WASM_TOOL_CONFIGURATIONS);
+        }
+    }
+    private void processWasmToolServices(DeploymentPhaseContext deploymentPhaseContext, List<AnnotationInstance> annotations) {
+        if (annotations == null || annotations.isEmpty()) {
+            return;
+        }
+        DeploymentUnit deploymentUnit = deploymentPhaseContext.getDeploymentUnit();
+        for (AnnotationInstance annotation : annotations) {
+            String name;
+            if (annotation.value("wasmToolConfigurationName") != null) {
+                name = annotation.value("wasmToolConfigurationName").asString();
+                deploymentUnit.addToAttachmentList(WasmAttachements.WASM_TOOL_NAMES, name);
+                deploymentPhaseContext.addDeploymentDependency(WASM_TOOL_PROVIDER_CAPABILITY.getCapabilityServiceName(name), WasmAttachements.WASM_TOOL_CONFIGURATIONS);
+            }
+        }
+    }
+}

--- a/wildfly-wasm/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
+++ b/wildfly-wasm/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.wildfly.extension.wasm.WasmExtension

--- a/wildfly-wasm/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/wildfly-wasm/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,1 @@
+org.wildfly.extension.wasm.WasmExtensionTransformerRegistration

--- a/wildfly-wasm/subsystem/src/main/resources/org/wildfly/extension/wasm/LocalDescriptions.properties
+++ b/wildfly-wasm/subsystem/src/main/resources/org/wildfly/extension/wasm/LocalDescriptions.properties
@@ -1,0 +1,20 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+wasm=The WASM subsystem
+wasm.add=This operation adds the WASM subsystem
+wasm.remove=This operation removes the WASM subsystem
+
+
+wasm.wasm-tool=A WASM tool definition.
+wasm.wasm-tool.description=The description of the WASM tool.
+wasm.wasm-tool.path=The path to the WASM binary.
+wasm.wasm-tool.relative-to=The fpath to which the path is relative to.
+wasm.wasm-tool.method=the name of the method or function to invoke on the WASM binary.
+wasm.wasm-tool.tool-args=The list of arguments to pass to the method invoked on the WASM binary.
+wasm.wasm-tool.tool-args.description=The description of the argument.
+wasm.wasm-tool.tool-args.name=The name of the argument.
+wasm.wasm-tool.tool-args.type=The type of the argument.
+wasm.wasm-tool.tool-args.required=The mandatory nature of the argument.

--- a/wildfly-wasm/subsystem/src/main/resources/schema/wildfly-wasm_1_0.xsd
+++ b/wildfly-wasm/subsystem/src/main/resources/schema/wildfly-wasm_1_0.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:wasm:1.0"
+           xmlns="urn:jboss:domain:wasm:1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+    <xs:element name="subsystem" type="subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                The Wasm subsystem root element.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                The Wasm subsystem root type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="wasm-tool" type="wasmToolType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        The Wasm tools.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="wasmToolType">
+        <xs:annotation>
+            <xs:documentation>
+                A WASM tool.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this tool.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The path on the server to the WASM binary.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The place to where the path is relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/wildfly-wasm/subsystem/src/test/java/org/wildfly/extension/wasm/WasmSubsystemTestCase.java
+++ b/wildfly-wasm/subsystem/src/test/java/org/wildfly/extension/wasm/WasmSubsystemTestCase.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.wasm;
+
+import java.util.EnumSet;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemSchemaTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class WasmSubsystemTestCase extends AbstractSubsystemSchemaTest<WasmSubsystemSchema> {
+
+    @Parameters
+    public static Iterable<WasmSubsystemSchema> parameters() {
+        return EnumSet.allOf(WasmSubsystemSchema.class);
+    }
+
+    public WasmSubsystemTestCase(WasmSubsystemSchema schema) {
+        super(WasmSubsystemRegistrar.NAME, new WasmExtension(), schema, WasmSubsystemSchema.CURRENT);
+    }
+}

--- a/wildfly-wasm/subsystem/src/test/resources/org/wildfly/extension/wasm/wasm-1.0.xml
+++ b/wildfly-wasm/subsystem/src/test/resources/org/wildfly/extension/wasm/wasm-1.0.xml
@@ -1,0 +1,10 @@
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<subsystem xmlns="urn:jboss:domain:wasm:1.0">
+    <wasm-tool name="chicory" path="/home/ehugonne/dev/AI/examples/greet.wasm"/>
+    <wasm-tool name="dice" path="/home/ehugonne/dev/AI/examples/roll-dice.wasm"/>
+    <wasm-tool name="pizza" path="/home/ehugonne/dev/AI/examples/hawaiian-pizza.wasm"/>
+</subsystem>


### PR DESCRIPTION
…a dedicated subsystem :

 * Providing a dedicated WASM subsystem
 * Adding support for service proxy and injection with dedicated annotation.
 * Adding support to be able to call HTTP resources.
 * Adding support to expose WASM binaries as MCP tools.
 * Extracting the conversion code into external classes.
 * Updating the code to avoid injecting the WASM tool but just providing a service interface over it.